### PR TITLE
1.49.0 increased retries

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -367,8 +367,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		params.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
 	}
 
-	// IAM changes can take 1 minute to propagate in AWS
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	// IAM changes can take 3 minute to propagate in AWS
+	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
 			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)
@@ -730,8 +730,8 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	if configUpdate {
 		log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
 
-		// IAM changes can take 1 minute to propagate in AWS
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		// IAM changes can take 3 minute to propagate in AWS
+		err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 			_, err := conn.UpdateFunctionConfiguration(configReq)
 			if err != nil {
 				log.Printf("[DEBUG] Received error modifying Lambda Function Configuration %s: %s", d.Id(), err)


### PR DESCRIPTION
### Increase timeout period for creating lambda functions
IAM seems to take more than a minute some times and we're semi-regularly hit with this error:

```
Error creating Lambda function: InvalidParameterValueException: The provided execution role does not have permissions to call SendMessage on SQS
```

Increasing this retry count might help.

### Retry read for a short period of time

Even though the create and update operations are retried, it seems like
it can happen that this `DescribeInstances` fails with
`InvalidInstanceID.NotFound`. The behaviour is slightly different when
this happens. The VM is created and terraform will succeed, yet the ID
is cleared and would not be returned in outputs.

```
13:06:38 aws_instance.test[0]: Creation complete after 23s
```

vs.

```
13:06:45 aws_instance.test[1]: Creation complete after 30s (ID: i-07cae8c777c189f80)
```

Retrying this might help the API hit another server that has this data.