### PR TITLE
Increase timeout for iam instance profile parameter

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -587,7 +587,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Run configuration: %s", runOpts)
 
 	var runResp *ec2.Reservation
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 		runResp, err = conn.RunInstances(runOpts)
 		// IAM instance profiles can take ~10 seconds to propagate in AWS:
@@ -960,7 +960,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, ok := d.GetOk("iam_instance_profile"); ok {
 			// Does not have an Iam Instance Profile associated with it, need to associate
 			if len(resp.IamInstanceProfileAssociations) == 0 {
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 					_, err := conn.AssociateIamInstanceProfile(&ec2.AssociateIamInstanceProfileInput{
 						InstanceId: aws.String(d.Id()),
 						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
@@ -983,7 +983,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				// Has an Iam Instance Profile associated with it, need to replace the association
 				associationId := resp.IamInstanceProfileAssociations[0].AssociationId
 
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 					_, err := conn.ReplaceIamInstanceProfileAssociation(&ec2.ReplaceIamInstanceProfileAssociationInput{
 						AssociationId: associationId,
 						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{


### PR DESCRIPTION
This increases the retry time on creating instances that fail due to
invalid instance profile values. This is typically an eventual
consistency problem. Even with the increased timeout, it's possible
that in certain time windows this would never succeed and just take
longer to fail. Increasing such timeouts have been quite successful
in the past though.